### PR TITLE
Added support for auto-mocking internal classes

### DIFF
--- a/source/NSubstituteAutoMocker.UnitTests/NSubstituteAutoMocker.UnitTests.csproj
+++ b/source/NSubstituteAutoMocker.UnitTests/NSubstituteAutoMocker.UnitTests.csproj
@@ -57,7 +57,10 @@
     <Compile Include="DocumentationSnippets\FirstExample.cs" />
     <Compile Include="NSubstituteAutoMockerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SamplesToTest\ClassWithInternalConstructor.cs" />
     <Compile Include="SamplesToTest\ClassWithPrimativeConstructors.cs" />
+    <Compile Include="SamplesToTest\IInternalInterface.cs" />
+    <Compile Include="SamplesToTest\InternalClass.cs" />
     <Compile Include="SamplesToTest\SealedClass.cs" />
     <Compile Include="SamplesToTest\ClassWithJustDefaultConstructor.cs" />
     <Compile Include="SamplesToTest\ClassWithPrivateDefaultConstructor.cs" />

--- a/source/NSubstituteAutoMocker.UnitTests/NSubstituteAutoMockerTests.cs
+++ b/source/NSubstituteAutoMocker.UnitTests/NSubstituteAutoMockerTests.cs
@@ -18,7 +18,7 @@ namespace NSubstituteAutoMocker.UnitTests
                 Assert.IsNotNull(autoMocker.ClassUnderTest);
             }
 
-            /* Don't think it make sense to throw exceptpion in this case
+            /* Don't think it make sense to throw exception in this case
             [TestMethod]
             [ExpectedException(typeof(ConstructorMatchException))]
             public void ThrowsExceptionIfNotAvailable()
@@ -43,6 +43,14 @@ namespace NSubstituteAutoMocker.UnitTests
 
             [TestMethod]
             public void ClassUnderTestCanBeSealed()
+            {
+                NSubstituteAutoMocker<SealedClass> autoMocker =
+                    new NSubstituteAutoMocker<SealedClass>();
+                Assert.IsNotNull(autoMocker.ClassUnderTest);
+            }
+
+            [TestMethod]
+            public void ClassUnderTestCanBeInternal()
             {
                 NSubstituteAutoMocker<SealedClass> autoMocker =
                     new NSubstituteAutoMocker<SealedClass>();
@@ -149,6 +157,14 @@ namespace NSubstituteAutoMocker.UnitTests
                     new NSubstituteAutoMocker<ClassWithDuplicateConstructorTypes>();
                 Assert.IsNotNull(autoMocker.Get<IDependency1>("dependencyTwo"));
             }
+        }
+
+        [TestMethod]
+        public void ItCallsInternalConstructorsThatItHasAccessTo()
+        {
+            var autoMocker = new NSubstituteAutoMocker<ClassWithInternalConstructor>();
+
+            Assert.IsNotNull(autoMocker.Get<IInternalInterface>());
         }
 
         // TODO Do I need to test the use of generics or collections?

--- a/source/NSubstituteAutoMocker.UnitTests/Properties/AssemblyInfo.cs
+++ b/source/NSubstituteAutoMocker.UnitTests/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/ClassWithInternalConstructor.cs
+++ b/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/ClassWithInternalConstructor.cs
@@ -1,0 +1,17 @@
+﻿namespace NSubstituteAutoMocker.UnitTests.SamplesToTest
+{
+    public class ClassWithInternalConstructor
+    {
+        internal IInternalInterface InternalInterface;
+
+        public ClassWithInternalConstructor()
+        {
+
+        }
+
+        internal ClassWithInternalConstructor(IInternalInterface internalInterface)
+        {
+            InternalInterface = internalInterface;
+        }
+    }
+}

--- a/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/IInternalInterface.cs
+++ b/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/IInternalInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace NSubstituteAutoMocker.UnitTests.SamplesToTest
+{
+    internal interface IInternalInterface
+    {
+
+    }
+}

--- a/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/InternalClass.cs
+++ b/source/NSubstituteAutoMocker.UnitTests/SamplesToTest/InternalClass.cs
@@ -1,0 +1,10 @@
+﻿namespace NSubstituteAutoMocker.UnitTests.SamplesToTest
+{
+    internal class InternalClass
+    {
+        internal InternalClass()
+        {
+            
+        }
+    }
+}

--- a/source/NSubstituteAutoMocker/NSubstituteAutoMocker.cs
+++ b/source/NSubstituteAutoMocker/NSubstituteAutoMocker.cs
@@ -45,7 +45,8 @@ namespace NSubstituteAutoMocker
             }
 
             object[] args = _constructors.Values.ToArray();
-            ClassUnderTest = Activator.CreateInstance(typeof(T), args) as T;
+            var bindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic;
+            ClassUnderTest = Activator.CreateInstance(typeof(T), bindingFlags, null, args, null) as T;
         }
 
         private object CreateInstance(Type type)
@@ -91,8 +92,9 @@ namespace NSubstituteAutoMocker
 
         private static ConstructorInfo GetHighestParameterCountConstructor(Type type)
         {
-            ConstructorInfo result = type.GetConstructors()[0];
-            foreach (ConstructorInfo constructorInfo in type.GetConstructors())
+            var bindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic;
+            ConstructorInfo result = type.GetConstructors(bindingFlags)[0];
+            foreach (ConstructorInfo constructorInfo in type.GetConstructors(bindingFlags))
             {
                 if (constructorInfo.GetParameters().Length > result.GetParameters().Length)
                 {


### PR DESCRIPTION
Had to change the logic for finding and calling constructors to include both Public, Instance, and Private constructors. Added corresponding tests. There is some risk to this change as right now it will use not only internal constructors (good thing) but also private constructors -- which could be a breaking change.

I'd love to have some discussion on this topic before accepting this pull request. Thanks!
